### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,6 @@
             "NotificationAPI": "src/"
         }
     },
-    "extra": {
-      "laravel": {
-        "providers": [
-          "NotificationAPI\\NotificationAPIProvider"
-        ]
-      }
-    },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "dev-master"
     },


### PR DESCRIPTION
On install this package by composer in some projects, after install the composer runs the "dump autoload" command and show error pointing ServiceProvider do not exists. impossibiliting the use o this package with composer.

![image](https://github.com/notificationapi-com/notificationapi-php-server-sdk/assets/25491752/d2d41553-aad8-4935-b881-73bc18084e80)
