### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,8 +8,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: cache-db
         with:
             path: ~/.symfony/cache

--- a/.github/workflows/pullRequests.yml
+++ b/.github/workflows/pullRequests.yml
@@ -8,8 +8,8 @@ jobs:
     name: Pull Request Pipeline
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: cache-db
         with:
             path: ~/.symfony/cache


### PR DESCRIPTION
Upgrade actions/checkout and actions/cache to v4 because of current versions of cache being deprecated